### PR TITLE
add try block to avoid ldap problems

### DIFF
--- a/flask_ldap_login/__init__.py
+++ b/flask_ldap_login/__init__.py
@@ -208,9 +208,11 @@ class LDAPLoginManager(object):
             if isinstance(opt, str):
                 opt = getattr(ldap, opt)
 
-            if isinstance(value, str):
-                value = getattr(ldap, value)
-
+            try:
+                if isinstance(value, str):
+                    value = getattr(ldap, value)
+            except AttributeError:
+                pass
             self.conn.set_option(opt, value)
 
         if self.config.get('START_TLS'):


### PR DESCRIPTION
Quoted from Thomas Caswell "...Stop pedantic errors which seems to be caused by an over-zealous normalization scheme which is converting strings into ldap constants."