### PR TITLE
Add _raise_errors property to LDAPLoginManager (default False)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,5 @@ coverage.xml
 # Sphinx documentation
 docs/_build/
 
+# PyCharm
+.idea/

--- a/flask_ldap_login/check.py
+++ b/flask_ldap_login/check.py
@@ -26,13 +26,15 @@ def main():
     module = import_string(import_name)
     app = getattr(module, appname)
 
-    userdata = app.ldap_login_manager.ldap_login(args.username, args.password)
-    if userdata is None:
-        print "Invalid username/password"
-    else:
-        print "Got userdata for %s" % args.username
-        pprint(userdata)
+    app.ldap_login_manager.set_raise_errors()
 
+    try:
+        userdata = app.ldap_login_manager.ldap_login(args.username, args.password)
+        print("Got userdata for %s" % args.username)
+        pprint(userdata)
+    except Exception as e:
+        print("User not found")
+        pprint(e)
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
Add functionality to allow for LDAPLoginManager to raise errors on
not successfully finding a user instead of returning None.
It will return a different error message for if no users were found
vs. mismatch of username password.

Also changed the check utility to print out the specific error that
was received.