### PR TITLE
Make distinguished name available as a object key

### DIFF
--- a/flask_ldap_login/__init__.py
+++ b/flask_ldap_login/__init__.py
@@ -98,7 +98,9 @@ class LDAPLoginManager(object):
         """
         if not results:
             return None
+        userdn = results[0][0]
         userobj = results[0][1]
+        userobj['dn'] = userdn
 
         keymap = self.config.get('KEY_MAP')
         if keymap:


### PR DESCRIPTION
So that a user can reference `dn` in their `KEY_MAP` configuration setting.