### PR TITLE
FIX: also test if option name is a unicode string

### DIFF
--- a/flask_ldap_login/__init__.py
+++ b/flask_ldap_login/__init__.py
@@ -236,11 +236,11 @@ class LDAPLoginManager(object):
         self.conn = ldap.initialize(self.config['URI'])
 
         for opt, value in self.config.get('OPTIONS', {}).items():
-            if isinstance(opt, str):
+            if isinstance(opt, basestring):
                 opt = getattr(ldap, opt)
 
             try:
-                if isinstance(value, str):
+                if isinstance(value, basestring):
                     value = getattr(ldap, value)
             except AttributeError:
                 pass


### PR DESCRIPTION
This bug prevented us from using @scragg0x's realms-wiki with custom LDAP options specified in json config file.

```python
 [...]
  File "/home/realms/.local/lib/python2.7/site-packages/flask_ldap_login/__init__.py", line 228, in ldap_login
    self.connect()
  File "/home/realms/.local/lib/python2.7/site-packages/flask_ldap_login/__init__.py", line 216, in connect
    self.conn.set_option(opt, value)
  File "/home/realms/.local/lib/python2.7/site-packages/ldap/ldapobject.py", line 652, in set_option
    return self._ldap_call(self._l.set_option,option,invalue)
  File "/home/realms/.local/lib/python2.7/site-packages/ldap/ldapobject.py", line 106, in _ldap_call
    result = func(*args,**kwargs)
TypeError: an integer is required
```