### PR TITLE
explicit absolute and relative imports

### DIFF
--- a/flask_ldap_login/__init__.py
+++ b/flask_ldap_login/__init__.py
@@ -40,6 +40,8 @@ update the application like::
 
 
 """
+from __future__ import absolute_import
+
 import logging
 
 import flask

--- a/flask_ldap_login/check.py
+++ b/flask_ldap_login/check.py
@@ -1,6 +1,8 @@
 """
 Check that application ldap creds are set up correctly.
 """
+from __future__ import absolute_import
+
 from argparse import ArgumentParser
 from pprint import pprint
 import getpass

--- a/flask_ldap_login/forms.py
+++ b/flask_ldap_login/forms.py
@@ -1,8 +1,11 @@
+from __future__ import absolute_import
+
 from flask.ext.wtf import Form
 import wtforms
 from wtforms import validators
 from flask import flash, current_app
 import ldap
+
 
 class LDAPLoginForm(Form):
     """


### PR DESCRIPTION
Lack of absolute imports can lead to `ImportError` in projects that use flask-ldap-login.

For example, if myproject has a `ldap.py` module and includes flask-ldap-login, the `import ldap`in `flask_ldap_login/forms.py` can lead to ambiguous imports in myproject.

The pull request just adds `from __future__ import absolute_import` to flask-ldap-login so that it does not happen anymore.

Thanks !
Stephane
