### PR TITLE
Use pyldap instead of python-ldap

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
 
     install_requires=['flask',
                       'flask-wtf',
-                      'python-ldap'
+                      'pyldap'
                       ],
 
     entry_points={


### PR DESCRIPTION
pyldap is a drop-in python-ldap replacement that works with Python 3.

https://github.com/pyldap/pyldap
