### PR TITLE
Fix for: FlaskWTFDeprecationWarning and  flask.ext is deprecated

### DIFF
--- a/flask_ldap_login/forms.py
+++ b/flask_ldap_login/forms.py
@@ -1,4 +1,4 @@
-from flask.ext.wtf import Form
+from flask_wtf import FlaskForm as Form
 import wtforms
 from wtforms import validators
 from flask import flash, current_app


### PR DESCRIPTION
- FlaskWTFDeprecationWarning: "flask_wtf.Form" has been renamed to "FlaskForm" and will be removed in 1.0.
- use flask_wtf import (flask.ext is deprecated)